### PR TITLE
link st against tinfo

### DIFF
--- a/experiments/Makefile
+++ b/experiments/Makefile
@@ -1,5 +1,5 @@
 all:
-	cc -g -o st scantest.c -lbluetooth -lcurses
+	cc -g -o st scantest.c -lbluetooth -lcurses -ltinfo
 	cc -g -o at advertisetest.c -lbluetooth -lcurses
 	cc -g -o ibeacon ibeacon.c -lbluetooth
 


### PR DESCRIPTION
Newer versions of ncurses seem to be split into two libraries, and `stdscr` belongs to `tinfo`.
